### PR TITLE
Fix for #7, by sending 400 (Bad Request) when POST and content-type is not application/json

### DIFF
--- a/api/routes.js
+++ b/api/routes.js
@@ -3,6 +3,14 @@ const crypto = require('crypto');
 const database = require('./database');
 const { URL } = require('url');
 
+function checkContentType(req, res, next) {
+    if (!req.is('application/json')) {
+        return res.status(400).send('Bad Rquest');
+    }
+
+    next();
+}
+
 const router = express.Router();
 
 router.get('/get-link', (req, res) => {
@@ -20,18 +28,14 @@ router.get(/^\/[0-9a-z]{64}/, (req, res) =>
         .catch(() => res.send({ result: false }))
 );
 
-router.post(/^\/[0-9a-z]{64}/, (req, res) => {
-    if (!req.is('application/json')) {
-        return res.status(400).send('Bad Rquest');
-    }
-
+router.post(/^\/[0-9a-z]{64}/, checkContentType, (req, res) =>
     database
         .post(req.path, req.body)
         .then(() => res.send({ result: true }))
         .catch(() => res.send({ result: false }))
-});
+)
 
-router.put(/^\/[0-9a-z]{64}/, (req, res) =>
+router.put(/^\/[0-9a-z]{64}/, checkContentType, (req, res) =>
     database
         .put(req.path, req.body)
         .then(() => res.send({ result: true }))

--- a/api/routes.js
+++ b/api/routes.js
@@ -20,12 +20,16 @@ router.get(/^\/[0-9a-z]{64}/, (req, res) =>
         .catch(() => res.send({ result: false }))
 );
 
-router.post(/^\/[0-9a-z]{64}/, (req, res) =>
+router.post(/^\/[0-9a-z]{64}/, (req, res) => {
+    if (!req.is('application/json')) {
+        return res.status(400).send('Bad Rquest');
+    }
+
     database
         .post(req.path, req.body)
         .then(() => res.send({ result: true }))
         .catch(() => res.send({ result: false }))
-);
+});
 
 router.put(/^\/[0-9a-z]{64}/, (req, res) =>
     database

--- a/server.js
+++ b/server.js
@@ -9,7 +9,9 @@ const port = process.env.PORT || 3000;
 const app = express();
 
 app.use(express.static(__dirname + '/client/dist'));
-app.use(bodyParser.json());
+app.use(bodyParser.json({
+  strict: false,
+}));
 app.use(cors());
 
 app.get('/', (req, res) => {


### PR DESCRIPTION
Only sending a generic `Bad Request`. IMO, should send a properly formatted error message. I could not find any example in code or documentation.