### PR TITLE
Fix images at the top of the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <p align="center">
-<img src="https://wpoffice365.com/wp-content/uploads/2017/07/react-logo.png" height="75" />
-<img src="https://i.cloudup.com/zfY6lL7eFa-3000x3000.png" height="75" />
-<img src="https://cdn-images-1.medium.com/max/960/1*pxfq-ikL8zPE3RyGB2xbng.png" height="75" />
-<img src="https://www.vectorlogo.zone/logos/js_webpack/js_webpack-card.png" height="75" />
+<img src="https://i.imgur.com/a4K03fL.png" height="75" />
+<img src="https://i.imgur.com/qjXkfUY.png" height="75" />
+<img src="https://i.imgur.com/S1Llv8Q.png" height="75" />
+<img src="https://i.imgur.com/9r1x8Cx.png" height="75" />
 </p>
 <p align="center">
 <a href="https://www.jsonstore.io/">


### PR DESCRIPTION
I've fixed the loading issues from the images at the top of the README by moving them all to the same domain and fixing the broken ones.